### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/schedule.yml
+++ b/.github/workflows/schedule.yml
@@ -1,4 +1,6 @@
 name: Update gist with WakaTime stats
+permissions:
+  contents: write
 on:
   schedule:
     - cron: "0 0 * * *"


### PR DESCRIPTION
Potential fix for [https://github.com/zanderlewis/waka-box-remastered/security/code-scanning/1](https://github.com/zanderlewis/waka-box-remastered/security/code-scanning/1)

To fix the issue, we need to add a `permissions` block to the workflow. Since the workflow interacts with a gist, it likely requires `contents: write` permissions. We will add the `permissions` block at the root level of the workflow to apply it to all jobs. This ensures that the `GITHUB_TOKEN` has only the necessary permissions.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
